### PR TITLE
improves version prep.

### DIFF
--- a/foo_app/apps.py
+++ b/foo_app/apps.py
@@ -1,6 +1,0 @@
-from django.apps import AppConfig
-
-
-class PollsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'polls'

--- a/foo_app/lib/version_helper.py
+++ b/foo_app/lib/version_helper.py
@@ -45,6 +45,7 @@ class GatherCommitAndBranchData:
         log.debug( f'final results_holder_dct, ```{pprint.pformat(results_holder_dct)}```' )
         self.commit = results_holder_dct['commit']
         self.branch = results_holder_dct['branch']
+        log.debug( f'self.branch, ``{self.branch}``' )
         return
 
     async def fetch_commit_data(self, results_holder_dct):
@@ -61,6 +62,7 @@ class GatherCommitAndBranchData:
             commit: str = commit_file.read_text().strip()
         else:  #if it's a detached HEAD, the commit hash is directly in the HEAD file
             commit: str = ref_line
+        log.debug( f'commit, ``{commit}``' )
         ## update holder --------------------------------------------
         results_holder_dct['commit'] = commit
         return
@@ -96,7 +98,9 @@ class GatherCommitAndBranchData:
             if line[0:1] == '*':
                 branch = line[2:]
                 break
+        log.debug( f'branch, ``{branch}``' )
         results_holder_dct['branch'] = branch
+        log.debug( f'results_holder_dct with branch, ``{pprint.pformat(results_holder_dct)}``' )
         return
 
 ## end class GatherCommitAndBranchData

--- a/foo_app/views.py
+++ b/foo_app/views.py
@@ -47,8 +47,11 @@ def version( request ):
     gatherer = GatherCommitAndBranchData()
     trio.run( gatherer.manage_git_calls )
     commit = gatherer.commit
+    log.debug( f'commit, ``{commit}``' )
     branch = gatherer.branch
-    info_txt = commit.replace( 'commit', branch )
+    log.debug( f'branch, ``{branch}``' )
+    # info_txt = commit.replace( 'commit', branch )
+    info_txt = f'{branch} {commit}'
     context = version_helper.make_context( request, rq_now, info_txt )
     output = json.dumps( context, sort_keys=True, indent=2 )
     log.debug( f'output, ``{output}``' )

--- a/foo_app/views.py
+++ b/foo_app/views.py
@@ -47,10 +47,7 @@ def version( request ):
     gatherer = GatherCommitAndBranchData()
     trio.run( gatherer.manage_git_calls )
     commit = gatherer.commit
-    log.debug( f'commit, ``{commit}``' )
     branch = gatherer.branch
-    log.debug( f'branch, ``{branch}``' )
-    # info_txt = commit.replace( 'commit', branch )
     info_txt = f'{branch} {commit}'
     context = version_helper.make_context( request, rq_now, info_txt )
     output = json.dumps( context, sort_keys=True, indent=2 )


### PR DESCRIPTION
New versions of git thrown an error if the user making a git-call doesn't have a github account. This causes issues with the subprocess git calls I was using. This updated code avoids the subprocess calls that can trigger the user-problem.